### PR TITLE
Fix creation of MongoDB connection string

### DIFF
--- a/library/wrappers/wrappermongodb/src/main/java/cz/matfyz/wrappermongodb/MongoDBProvider.java
+++ b/library/wrappers/wrappermongodb/src/main/java/cz/matfyz/wrappermongodb/MongoDBProvider.java
@@ -60,14 +60,16 @@ public class MongoDBProvider implements AbstractDatasourceProvider {
             final var sb = new StringBuilder()
                 .append("mongodb://");
 
-            if (username != null)
-                sb.append(username);
+            if (username != null && !username.isEmpty()) {
+                sb.append(username).append(":");
 
-            if (password != null)
-                sb.append(":").append(password);
+                if (password != null)
+                    sb.append(password);
+
+                sb.append("@");
+            }
 
             sb
-                .append("@")
                 .append(host)
                 .append(":")
                 .append(port)
@@ -83,14 +85,16 @@ public class MongoDBProvider implements AbstractDatasourceProvider {
             final var sb = new StringBuilder()
                 .append("mongodb://");
 
-            if (username != null)
-                sb.append(username);
+            if (username != null && !username.isEmpty()) {
+                sb.append(username).append(":");
 
-            if (password != null)
-                sb.append(":").append(password);
+                if (password != null)
+                    sb.append(password);
+
+                sb.append("@");
+            }
 
             sb
-                .append("@")
                 .append(host)
                 .append(":")
                 .append(port)


### PR DESCRIPTION
The resulting MongoDB connection string with no `username` and `password` currently looks like this:
`mongodb://@host:port/database`
which is not valid.

According to [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/connection-string-formats/#standard-connection-string-format), the connection string has the following format:
`mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]`
Therefore, the connection string without the username should look like this (there is no `@` at the beggining):
`mongodb://host:port/database`

I treat an empty username in the same way as null here.